### PR TITLE
fix: correct API baseURL in EventService.js

### DIFF
--- a/src/services/EventService.js
+++ b/src/services/EventService.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 const apiClient = axios.create({
   // baseURL: 'https://my-json-server.typicode.com/Code-Pop/Real-World_Vue-3',
-  baseURL: 'my-json-server.typicode.com/{yutaasakura96}/{world-vue}/events',
+  baseURL: 'https://my-json-server.typicode.com/yutaasakura96/world-vue/events',
   withCredentials: false,
   headers: {
     Accept: 'application/json',


### PR DESCRIPTION
- Updated the baseURL in EventService.js to use the full HTTPS path for my-json-server.
- Ensures correct API requests are made to the mock server for event data.